### PR TITLE
Clean Team page

### DIFF
--- a/src/app/util/event-utils.ts
+++ b/src/app/util/event-utils.ts
@@ -114,7 +114,7 @@ export class EventSorter {
 
     return items;
   }
-
+  
   private partition(items, pivot, left, right) {
     const pivotValue = items[pivot];
     let partitionIndex = left;
@@ -129,11 +129,22 @@ export class EventSorter {
     this.swap(items, right, partitionIndex);
     return partitionIndex;
   }
-
+  
   private swap(items, index1, index2) {
     const temp = items[index1];
     items[index1] = items[index2];
     items[index2] = temp;
   }
+  
+  public sortRev(items, left, right) {
+  
+	  this.sort(items, left, right);
+	  // reverse order
+      for (let i=0; i<(right+1-left)/2; i++) {
+		  this.swap(items, left+i, right-i);
+	  }
 
+    return items;
+  }
+  
 }

--- a/src/app/views/team/team.component.html
+++ b/src/app/views/team/team.component.html
@@ -80,7 +80,10 @@
               <span><span class="fa fa-map-marker"></span> {{ event.city }}, {{ event.state_prov }}, {{ event.country }}</span>
             </div>
             <div>
-              <span><span class="fa fa-calendar"></span> {{ event.start_date | date :  "mediumDate"}} - {{ event.end_date | date :  "mediumDate" }}</span>
+	  
+	      <!--    <span><span class="fa fa-calendar"></span> {{ event.start_date | date :  "mediumDate"}} - {{ event.end_date | date :  "mediumDate" }}</span> -->
+              <span *ngIf="event.start_date == event.end_date"><span class="fa fa-calendar"></span> {{ event.start_date | date :  "mediumDate"}} </span>
+			  <span *ngIf="event.start_date != event.end_date"><span class="fa fa-calendar"></span> {{ event.start_date | date :  "mediumDate"}} - {{ event.end_date | date :  "mediumDate" }}</span>
             </div>
             <div *ngIf="event.ranking">
               <span>Overall team {{ team_key }} was <b>Rank {{ event.ranking.rank }}</b> with a record of <b>{{ event.ranking.wins }}-{{ event.ranking.losses }}-{{ event.ranking.ties }}</b></span>
@@ -589,3 +592,4 @@
 
   </div>
 </main>
+

--- a/src/app/views/team/team.component.ts
+++ b/src/app/views/team/team.component.ts
@@ -98,7 +98,7 @@ export class TeamComponent implements OnInit {
   }
 
   getEventMatches() {
-    this.team.events = this.event_sorter.sort(this.team.events, 0, this.team.events.length - 1);
+    this.team.events = this.event_sorter.sortRev(this.team.events, 0, this.team.events.length - 1);
 
     for (const event of this.team.events) {
       this.ftc.getEventMatches(event.event_key, this.convertSeason(this.current_season)).subscribe((data) => {


### PR DESCRIPTION
Shows team events with recent/live events at the top in reverse chronological order.
Shows single day events as a single date instead of date-date format.
![ss teampage](https://user-images.githubusercontent.com/14369420/33627009-39d17a60-d9ca-11e7-9b3d-f5fd1c864f5e.PNG)
