### PR TITLE
Event page improvements

### DIFF
--- a/src/app/views/event/event.component.html
+++ b/src/app/views/event/event.component.html
@@ -72,11 +72,13 @@
   <div class="row" *ngIf="totalteams>0">
     <div class="col-xs-12">
       <ul class="nav nav-tabs">
-        <li role="presentation" [class.active]="isSelected('matches')"><a (click)="select('matches')">Results</a></li>
-        <li role="presentation" [class.active]="isSelected('rankings')"><a (click)="select('rankings')">Rankings</a></li>
-        <li role="presentation" [class.active]="isSelected('awards')"><a (click)="select('awards')">Awards</a></li>
-        <li role="presentation" [class.active]="isSelected('teams')"><a (click)="select('teams')">Teams <span class="badge" [innerHTML]="totalteams"></span></a></li>
-        <!--<li role="presentation" [class.active]="isSelected('advancement')"><a (click)="select('adancment')">Advancement</a></li>-->
+
+        <li role="presentation" [class.active]="isSelected('rankings')"><a (click)="select('rankings')">Rankings <span class="badge" [innerHTML]="totalrankings"></span></a></li>
+        <li role="presentation" [class.active]="isSelected('matches')"><a (click)="select('matches')">Matches <span class="badge" [innerHTML]="totalmatches"></span></a></li>
+        <li role="presentation" [class.active]="isSelected('awards')"><a (click)="select('awards')">Awards <span class="badge" [innerHTML]="totalawards"></span></a></li>
+		<li role="presentation" [class.active]="isSelected('teams')"><a (click)="select('teams')">Teams <span class="badge" [innerHTML]="totalteams"></span></a></li>
+
+        <!--<li role="presentation" [class.active]="isSelected('advancement')"><a (click)="select('advancement')">Advancement</a></li>-->
       </ul>
     </div>
   </div>

--- a/src/app/views/event/event.component.ts
+++ b/src/app/views/event/event.component.ts
@@ -16,6 +16,9 @@ export class EventComponent implements OnInit {
   event_key: string;
   event: any;
   totalteams: any;
+  totalmatches: any;
+  totalrankings: any;
+  totalawards: any;
   view_type: string;
 
   constructor(private ftc: FTCDatabase, private route: ActivatedRoute, private router: Router, private globaltoa:TheOrangeAllianceGlobals) {
@@ -33,9 +36,20 @@ export class EventComponent implements OnInit {
         this.event.rankings = data[4];
         this.event.awards = data[5];
         this.event.teams = data[6];
-        this.select('matches');
+		
+		if (this.event.rankings.length>0) {
+		  this.select('rankings');
+		} else if (this.event.matches.length>0) {
+		  this.select('matches')
+		} else {
+		  this.select('teams');
+		}
+		
         this.event_parser = new EventParser(this.event);
         this.totalteams =  this.event.teams.length;
+		this.totalmatches =  this.event.matches.length;
+		this.totalrankings =  this.event.rankings.length;
+		this.totalawards =  this.event.awards.length;
         this.globaltoa.setTitle(this.event.event_name);
       }, (err) => {
         console.log(err);


### PR DESCRIPTION
Reorder event tabs w/ Rankings first
Change "Results" tab to "Matches" for clarity
Set default active tab to be most useful tab
  Teams if only team info exists
  Matches if only match schedule exists
  Rankings otherwise
Add # of entries in each tab (like teams) so users see which tabs are populated without having to click them.