### PR TITLE
Add sort of teams by team number to correct for lack of sorting by API

### DIFF
--- a/src/app/providers/ftc-database.ts
+++ b/src/app/providers/ftc-database.ts
@@ -71,7 +71,9 @@ export class FTCDatabase {
   public getAllTeams(): Promise<Team[]> {
     return new Promise<Team[]>((resolve, reject) => {
       this.request('/team').then((data: any[]) => {
-        resolve(data.map((result: any) => new Team().fromJSON(result)));
+        resolve(
+          data.map((result: any) => new Team().fromJSON(result))
+          .sort((a: Team, b: Team) => (a.teamNumber - b.teamNumber)));
       }).catch((err: any) => reject(err));
     });
   }


### PR DESCRIPTION
Fixes #167 by implementing a sort on the retrieved data.  This is far less ideal than having the API do the sort, but sometimes that's outside your control.

Good Luck, from a [FRC Team 135 (Black Knights)](http://team135.org/) Alum.