### PR TITLE
Make the title bar white, and clickable, and make other icons white too

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,8 +1,9 @@
 <!-- AppBar -->
 <mdc-top-app-bar #topAppBar fixed style="z-index: 7" [dir]="'config.direction' | translate">
   <mdc-top-app-bar-row>
-    <mdc-top-app-bar-section align="start" [title]="title || 'The Orange Alliance'">
+    <mdc-top-app-bar-section align="start">
       <mdc-icon mdcTopAppBarNavIcon svgIcon="menu" (click)="appdrawer.open = !appdrawer.open" *ngIf="isScreenSmall() || topAppBar.isCollapsed()"></mdc-icon>
+      <a class="mdc-top-app-bar__title" onclick="location.reload();">{{title || 'The Orange Alliance'}}</a>
       <!--<mdc-icon mdcTopAppBarNavIcon svgIcon="menu" (click)="back()" *ngIf="!isScreenSmall() && !topAppBar.isCollapsed()"></mdc-icon>-->
     </mdc-top-app-bar-section>
     <mdc-top-app-bar-section align="end">

--- a/src/app/views/home/home.component.scss
+++ b/src/app/views/home/home.component.scss
@@ -23,7 +23,7 @@
   background: $mdc-theme-primary;
   margin-left: 10px;
   border-radius: 50px;
-  color: #000;
+  color: #fff;
   height: 50px;
   width: 50px;
   position: absolute;
@@ -37,7 +37,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   height: 24px;
-  fill: #000;
+  fill: #fff;
 }
 
 .fun-logo {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -83,11 +83,12 @@ mdc-text-field .mdc-floating-label {
 }
 
 .mdc-top-app-bar {
-  color: #000;
+  color: #fff;
+  user-select: none;
 }
 
 .mdc-top-app-bar .mdc-top-app-bar__navigation-icon {
-  color: #000;
+  color: #fff;
 }
 
 mdc-icon svg {


### PR DESCRIPTION
Black and orange usually tend to clash and not look well together. I've turned this:
![image](https://user-images.githubusercontent.com/24400628/53376981-f6e09f80-3925-11e9-8320-a0b71b584265.png)
Into this:
![image](https://user-images.githubusercontent.com/24400628/53376997-0829ac00-3926-11e9-9bb7-505c6ef7c3a5.png)

You can also now click the title to reload the page