### PR TITLE
No results have been reported less of an eyesore.

### DIFF
--- a/src/app/views/event/event.component.html
+++ b/src/app/views/event/event.component.html
@@ -42,7 +42,7 @@
     <div class="col-12">
       <mdc-card class="toa-card">
         <div style="color: #757575; text-align: center">
-          <div mdcHeadline6 [innerHTML]="'no_data.event_long' | translate"></div>
+          <div mdcHeadline6 class="p-3" [innerHTML]="'no_data.event_long' | translate"></div>
         </div>
       </mdc-card>
     </div>

--- a/src/app/views/event/event.component.html
+++ b/src/app/views/event/event.component.html
@@ -39,7 +39,13 @@
   </div>
 
   <div class="mt-3 row" *ngIf="totalteams === 0 && totalmatches === 0 && totalrankings === 0 && totalawards === 0">
-    <h4 class="col-12">{{ 'no_data.event_long' | translate }}</h4>
+    <div class="col-12">
+      <mdc-card class="toa-card">
+        <div style="color: #757575; text-align: center">
+          <div mdcHeadline6 [innerHTML]="'no_data.event_long' | translate"></div>
+        </div>
+      </mdc-card>
+    </div>
   </div>
   <div class="mt-3 row" *ngIf="admin || totalmedia > 0 || totalteams > 0 || totalmatches > 0 || totalrankings > 0 || totalalliances > 0|| totalawards > 0">
     <div class="col-12">

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -395,7 +395,7 @@
     "teams": "No teams found",
     "teams_long": "There are no teams that match that query",
     "events": "No events found",
-    "event_long": "NO RESULTS HAVE BEEN REPORTED FOR THIS EVENT.",
+    "event_long": "No results have been reported for this event.",
     "streams_long": "There are currently no active streams.",
     "events_for_season": "No events for {{ season }} season",
     "events_for_season_long": "This team hasn't yet played at any events this season.<br/>Try changing the season using the selector above.",


### PR DESCRIPTION
## OLD:
![image](https://user-images.githubusercontent.com/24400628/68918698-f5b20580-0734-11ea-8c6f-7356e3f99ca6.png)

## NEW:
![image](https://user-images.githubusercontent.com/24400628/68918842-7a9d1f00-0735-11ea-9da1-6571c61621a5.png)



### Based off of this to keep consistency:
![image](https://user-images.githubusercontent.com/24400628/68918732-167a5b00-0735-11ea-9c6e-3950392d4fcf.png)
