### PR TITLE
Small fix to Skystone insights

### DIFF
--- a/src/app/models/game-specifics/SkystoneInsights.ts
+++ b/src/app/models/game-specifics/SkystoneInsights.ts
@@ -65,7 +65,7 @@ export default class SkystoneInsights extends Insights implements ISerializable 
 
   fromJSON(json: any): SkystoneInsights {
     const skystone: SkystoneInsights = new SkystoneInsights();
-    skystone.highScoreMatch = json.high_score_match;
+    skystone.highScoreMatch = json.high_score_match ? new Match().fromJSON(json.high_score_match) : null;
     skystone.averageMatchScore = json.average_match_score;
     skystone.averageWinningScore = json.average_winning_score;
     skystone.averageWinningMargin = json.average_winning_margin;

--- a/src/app/models/game-specifics/SkystoneInsights.ts
+++ b/src/app/models/game-specifics/SkystoneInsights.ts
@@ -1,5 +1,6 @@
-import Insights from '../Insights';
 import {ISerializable} from '../ISerializable';
+import Insights from '../Insights';
+import Match from '../Match';
 
 export default class SkystoneInsights extends Insights implements ISerializable {
   private _autoAverageSkystonesDelivered: number;


### PR DESCRIPTION
Small fix to an issue I saw the other day, insights for Skystone were displaying `NaN` as a high score because the high score Match's JSON wasn't being parsed.

**Current**
<img alt="screenshot" src="https://user-images.githubusercontent.com/6354860/109155282-3a905e80-7724-11eb-8c8a-52acb74f8798.png" width=300>

**Change**
<img alt="screenshot" src="https://i.imgur.com/lE1TpR5.png" width=300>