### PR TITLE
Resolve Auto Bonus Issues

### DIFF
--- a/src/app/views/matches/years/MatchBreakdown2122.ts
+++ b/src/app/views/matches/years/MatchBreakdown2122.ts
@@ -39,7 +39,7 @@ export default class MatchBreakdown2122 {
       MatchBreakdownTitle('Driver-Controlled', match.redTeleScore, match.blueTeleScore),
       MatchBreakdownField('Storage Unit Freight', red.teleStorageFreight, blue.teleStorageFreight, 1),
       MatchBreakdownField('Level 1 Cargo', red.teleFreight1, blue.teleFreight1, 2),
-      MatchBreakdownField('Level 2 Cargo', red.teleFreight2, blue.teleFreight2, 3),
+      MatchBreakdownField('Level 2 Cargo', red.teleFreight2, blue.teleFreight2, 4),
       MatchBreakdownField('Level 3 Cargo', red.teleFreight3, blue.teleFreight3, 6),
       MatchBreakdownField('Shared Hub Freight', red.sharedFreight, blue.sharedFreight, 4),
 

--- a/src/app/views/matches/years/MatchBreakdown2122.ts
+++ b/src/app/views/matches/years/MatchBreakdown2122.ts
@@ -17,9 +17,9 @@ export default class MatchBreakdown2122 {
     const blue: FreightFrenzyAllianceDetails = details.blueDtls;
 
     const red1AutoBonusPts = red.barcode1 === 'DUCK' ? 10 : 20;
-    const red2AutoBonusPts = red.barcode1 === 'DUCK' ? 10 : 20;
-    const blue1AutoBonusPts = red.barcode1 === 'DUCK' ? 10 : 20;
-    const blue2AutoBonusPts = red.barcode1 === 'DUCK' ? 10 : 20;
+    const red2AutoBonusPts = red.barcode2 === 'DUCK' ? 10 : 20;
+    const blue1AutoBonusPts = blue.barcode1 === 'DUCK' ? 10 : 20;
+    const blue2AutoBonusPts = blue.barcode2 === 'DUCK' ? 10 : 20;
 
     // TODO: Replace team 1 and 2 with actual team numbers?
     return [
@@ -33,8 +33,8 @@ export default class MatchBreakdown2122 {
       MatchBreakdownField('Level 3 Cargo', red.autoFreight3, blue.autoFreight3, 6),
       MatchBreakdownFreightFrenzyBarcodeElement('Barcode Element 1', red.barcode1, blue.barcode1),
       MatchBreakdownFreightFrenzyBarcodeElement('Barcode Element 2', red.barcode2, blue.barcode2),
-      MatchBreakdownBoolFieldVariable('Robot 1 Bonus', red.autoBonus1, blue.autoBonus1, red1AutoBonusPts, blue1AutoBonusPts ),
-      MatchBreakdownBoolFieldVariable('Robot 2 Bonus', red.autoBonus2, blue.autoBonus1, red2AutoBonusPts, blue2AutoBonusPts ),
+      MatchBreakdownBoolFieldVariable('Robot 1 Bonus', red.autoBonus1, blue.autoBonus1, red1AutoBonusPts, blue1AutoBonusPts),
+      MatchBreakdownBoolFieldVariable('Robot 2 Bonus', red.autoBonus2, blue.autoBonus2, red2AutoBonusPts, blue2AutoBonusPts),
 
       MatchBreakdownTitle('Driver-Controlled', match.redTeleScore, match.blueTeleScore),
       MatchBreakdownField('Storage Unit Freight', red.teleStorageFreight, blue.teleStorageFreight, 1),


### PR DESCRIPTION
There's two issues with auto bonuses that make it appear like teams are not gaining the correct amount of points in auto.

Ex. Fruitport Q1: Blue appears to only get +10 points for a Team Element bonus where they should get +20 points each. The totals are reflective of the correct amount, but the GUI appears differently. This is resolved with changes on lines 20-22.

Ex. Fruitport Q42. Blue appears to have scored 40 bonus points despite only placing 1 block correctly. Again, this is a graphical error since the total is correct. This is resolved with the change to line 37.