### PR TITLE
Remove duplicate capped field in MatchBreakdown2122

### DIFF
--- a/src/app/views/matches/years/MatchBreakdown2122.ts
+++ b/src/app/views/matches/years/MatchBreakdown2122.ts
@@ -49,7 +49,6 @@ export default class MatchBreakdown2122 {
       MatchBreakdownTitle('End Game', match.redEndScore, match.blueEndScore),
       MatchBreakdownField('Duck or Shipping Element Delivered', red.endDelivered, blue.endDelivered, 6),
       MatchBreakdownField('Shipping Hub Capped', red.capped , blue.capped, 15),
-      MatchBreakdownField('Shipping Hub Capped', red.capped , blue.capped, 15),
       MatchBreakdownBoolField('Alliance Hub Balanced', red.allianceBalanced, blue.allianceBalanced, 10),
       MatchBreakdownBoolField('Shared Hub Unbalanced', red.sharedUnbalanced, blue.sharedUnbalanced, 20),
       MatchBreakdownFreightFrenzyParkingLocation('Robot 1 Navigated', red.endParked1, blue.endParked1),


### PR DESCRIPTION
The Shipping Hub Capped field displays the same thing twice. This was likely an attempt to encapsulate that there are two opportunities to cap, however capped itself is either 0, 1, or 2 to represent this. Duplicating it shows it in the UI twice for no reason.

![image](https://user-images.githubusercontent.com/16172089/163656782-09630252-5a23-4eaa-939f-30a2a9375c98.png)
