### PR TITLE
Add Average RP column to rankings views

### DIFF
--- a/src/app/util/ranking-utils.ts
+++ b/src/app/util/ranking-utils.ts
@@ -16,6 +16,12 @@ export class RankingSorter {
     }
   }
 
+  public byAverageRP(rankings: Ranking[]) {
+    if(rankings) {
+      rankings.sort((a, b) => b.rankingPoints / b.played - a.rankingPoints / a.played);
+    }
+  }
+
   public byOpr(rankings: Ranking[]) {
     if(rankings) {
       rankings.sort((a, b) => b.opr - a.opr);  // note sort descending

--- a/src/app/views/event/subviews/event-rankings/event-rankings.component.html
+++ b/src/app/views/event/subviews/event-rankings/event-rankings.component.html
@@ -17,6 +17,9 @@
             >{{ 'pages.event.subpages.rankings.ranking_points' | translate }}</th>
         <th mdcDataTableHeaderCell numeric *ngIf="showTieBreakerPoints"
             >{{ 'pages.event.subpages.rankings.tie_reaker_points' | translate }}</th>
+        <th mdcDataTableHeaderCell
+            ><button mdc-icon-button (click)="sorter.byAverageRP(rankings)"><mdc-icon svgIcon="sort"></mdc-icon></button
+            >{{ 'pages.event.subpages.rankings.average_rp' | translate }}</th>
         <th mdcDataTableHeaderCell numeric *ngIf="showHighScore"
             >{{ 'pages.event.subpages.rankings.highest_score' | translate }}</th>
         <th mdcDataTableHeaderCell numeric
@@ -41,6 +44,7 @@
         <td mdcDataTableCell numeric *ngIf="showQualPoints">{{ rank.qualifyingPoints }}</td>
         <td mdcDataTableCell numeric>{{ rank.rankingPoints.toFixed(2) }}</td>
         <td mdcDataTableCell numeric *ngIf="showTieBreakerPoints">{{ rank.tieBreakerPoints.toFixed(2) }}</td>
+        <td mdcDataTableCell numeric>{{ (rank.rankingPoints / rank.played).toFixed(2) }}</td>
         <td mdcDataTableCell numeric *ngIf="showHighScore">{{ rank.highestQualScore }}</td>
         <td mdcDataTableCell numeric>{{ rank.played }}</td>
         <td mdcDataTableCell numeric *ngIf="showOPR">{{ rank.opr.toFixed(1) }}</td>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -226,8 +226,9 @@
           "team": "Team",
           "wlt_record": "W-L-T",
           "qual_points": "Qualification Points",
-          "ranking_points": "Ranking Points",
+          "ranking_points": "Ranking Points (RP)",
           "tie_reaker_points": "Tie Breaker Points",
+	  "average_rp": "Average RP",
           "highest_score": "Highest Score",
           "matches_played": "Matches Played",
           "what_is_opr": "Offensive Power Rating, also know as OPR, is a stat that is often used in the FIRST community to compare the performance of teams on the field. OPRs are an interesting way to slice the data for teams at particular events, but aren't a perfect system for assessing a team's performance or contribution."

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -222,6 +222,7 @@
           "qual_points": "Puntos de calificación",
           "ranking_points": "Puntos de ranking",
           "tie_reaker_points": "Puntos de desempate",
+	  "average_rp": "Puntos de ranking moyen",
           "highest_score": "Puntuación más alta",
           "matches_played": "Partidos jugados",
           "what_is_opr": "La clasificación de potencia ofensiva, también conocido como CPO, es una estadística que se utiliza a menudo en la comunidad FIRST para comparar el rendimiento de los equipos sobre el terreno. Los CPO son una forma interesante de segmentar los datos de los equipos en eventos concretos, pero no son un sistema perfecto para evaluar el rendimiento o la contribución de un equipo."

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -222,6 +222,7 @@
           "qual_points": "נקודות Qualification",
           "ranking_points": "נקודות Ranking",
           "tie_reaker_points": "נקודות שובר שיוויון",
+	  "average_rp": "ממוצעות נקודות Ranking",
           "highest_score": "הניקוד הכי גבוה",
           "matches_played": "מקצים ששוחקו",
           "what_is_opr": "Offensive Power Rating, הידוע גם כ־OPR, הוא סטטיסטיקה המשומשת לעיתים קרובות בקהילת FIRST בכדי להשוות את הביצועים של קבוצות על המגרש. OPR זה דרך מעניינת לפרוס את הנתונים עבור קבוצות באירועים מסוימים, אבל זה לא תמיד המערכת הכי טובה להערכת הביצועים של קבוצה."

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -223,6 +223,7 @@
                     "qual_points": "Puncte de Calificare",
                     "ranking_points": "Puncte de Clasare",
                     "tie_reaker_points": "Puncte de Tiebreaker",
+                    "average_rp": "Puncte Medii de Clasare",
                     "highest_score": "Cel mai mare Scor",
                     "matches_played": "Meciuri Jucate",
                     "what_is_opr": "Offensive Power Rating, also know as OPR, is a stat that is often used in the FIRST community to compare the performance of teams on the field. OPRs are an interesting way to slice the data for teams at particular events, but aren't a perfect system for assessing a team's performance or contribution."

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -222,6 +222,7 @@
           "qual_points": "资格点数",
           "ranking_points": "排名点数",
           "tie_reaker_points": "决胜局点数",
+	  "average_rp": "平均排名点数",
           "highest_score": "最高分",
           "matches_played": "赛数总计",
           "what_is_opr": "进攻能力评分，也称为OPR，是FIRST社区中经常使用的一项统计数据，用于比较团队的赛场表现。 OPR是一种在特定事件中为团队分割数据的方式，但它并不是评估团队绩效或贡献的理想系统。"


### PR DESCRIPTION
While an event is occurring, the sum of RP is not particularly useful for a comparison across teams as some teams have played more matches than others. However, by taking the average RP per match, a direct comparison can be made, that once everyone has played the same number of qualification matches is equivalent.